### PR TITLE
add a test for all detectors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "dbetto",
-    "legend-pygeom-hpges >=0.7.0",
+    "legend-pygeom-hpges >=0.10.0",
     "legend-pygeom-tools >=0.0.23",
     "numpy",
     "pint",

--- a/src/pygeomhades/configs/holder_wrap/B00000B.yaml
+++ b/src/pygeomhades/configs/holder_wrap/B00000B.yaml
@@ -13,10 +13,10 @@ holder:
     cylinder:
       inner:
         height_in_mm: 62.5
-        radius_in_mm: 41.0
+        radius_in_mm: 39.5
       outer:
         height_in_mm: 65.5
-        radius_in_mm: 39.5
+        radius_in_mm: 41.0
     edge:
       height_in_mm: 0
       radius_in_mm: 0

--- a/src/pygeomhades/configs/holder_wrap/V04549A.yaml
+++ b/src/pygeomhades/configs/holder_wrap/V04549A.yaml
@@ -5,7 +5,7 @@ holder:
   geometry:
     bottom_cyl:
       inner:
-        height_in_mm: -84.1
+        height_in_mm: 25.4
         radius_in_mm: 8.0
       outer:
         height_in_mm: 25.4

--- a/src/pygeomhades/core.py
+++ b/src/pygeomhades/core.py
@@ -175,9 +175,7 @@ def construct(
     reg.addVolumeRecursive(pv)
 
     # construct the hpge, for now do not allow cylindrical asymmetry
-    detector_lv = make_hpge(
-        hpge_meta, name=hpge_meta.name, registry=reg, allow_cylindrical_asymmetry=False
-    )
+    detector_lv = make_hpge(hpge_meta, name=hpge_meta.name, registry=reg, allow_cylindrical_asymmetry=False)
     detector_lv.pygeom_color_rgba = [0.33, 0.33, 0.33, 1.0]
 
     # an extra offset is needed to account for the different reference point

--- a/src/pygeomhades/core.py
+++ b/src/pygeomhades/core.py
@@ -177,6 +177,12 @@ def construct(
     # construct the hpge
     detector_lv = make_hpge(hpge_meta, name=hpge_meta.name, registry=reg)
     detector_lv.pygeom_color_rgba = [0.33, 0.33, 0.33, 1.0]
+    
+    # construct the hpge, for now do not allow cylindrical asymmetry
+    detector_lv = make_hpge(
+        hpge_meta, name=hpge_meta.name, registry=reg, allow_cylindrical_asymmetry=False
+    )
+    detector_lv.pygeom_color_rgba = [0.33, 0.33, 0.33, 1.0]
 
     # an extra offset is needed to account for the different reference point
     # this is the top of the crystal in the original GDML but it's the p+ contact here

--- a/src/pygeomhades/core.py
+++ b/src/pygeomhades/core.py
@@ -174,10 +174,6 @@ def construct(
     pv = _place_pv(holder_lv, "holder_pv", cavity_lv, reg, z_in_mm=z_pos)
     reg.addVolumeRecursive(pv)
 
-    # construct the hpge
-    detector_lv = make_hpge(hpge_meta, name=hpge_meta.name, registry=reg)
-    detector_lv.pygeom_color_rgba = [0.33, 0.33, 0.33, 1.0]
-    
     # construct the hpge, for now do not allow cylindrical asymmetry
     detector_lv = make_hpge(
         hpge_meta, name=hpge_meta.name, registry=reg, allow_cylindrical_asymmetry=False

--- a/src/pygeomhades/metadata.py
+++ b/src/pygeomhades/metadata.py
@@ -23,6 +23,6 @@ class _DiodeProxy:
         det = self.dummy_detectors[det_name[0] + "99000A"]
         m = copy.copy(det)
         m.name = det_name
-        m.production.order = int(det_name[1:2])
+        m.production.order = int(det_name[1:3])
         m.production.slice = "A"
         return m

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+from importlib import resources
+from pathlib import Path
 
 import pygeomtools
 from dbetto import AttrsDict
@@ -102,3 +104,15 @@ def test_translate_to_detector_frame():
     assert x == 0.0
     assert y == 0.0
     assert z == 38.0
+
+def test_all_detectors():
+    dets = Path(resources.files("pygeomhades") / "configs" / "holder_wrap").glob("*.yaml")
+
+    for det in dets:
+        reg = construct(
+            str(det.stem),
+            "am_HS1_top_dlt",
+            config={"lead_castle_idx": 2},
+            public_geometry=True,
+        )
+        assert isinstance(reg, geant4.Registry)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -29,7 +29,7 @@ def test_construct():
                 "daq_settings": daq_settings,
             }
         ),
-        public_geometry=True,
+        public_geometry=public_geom,
     )
     assert isinstance(reg, geant4.Registry)
     pygeomtools.geometry.check_registry_sanity(reg, reg)
@@ -46,7 +46,7 @@ def test_construct():
                 "daq_settings": daq_settings2,
             }
         ),
-        public_geometry=True,
+        public_geometry=public_geom,
     )
 
     # Copper plate should be present
@@ -66,7 +66,7 @@ def test_construct():
                     "source_position": pos,
                 }
             ),
-            public_geometry=True,
+            public_geometry=public_geom,
         )
 
         assert isinstance(reg, geant4.Registry)
@@ -86,7 +86,7 @@ def test_construct():
                     "source_position": pos,
                 }
             ),
-            public_geometry=True,
+            public_geometry=public_geom,
         )
 
 
@@ -94,19 +94,23 @@ def test_all_detectors():
     dets = Path(resources.files("pygeomhades") / "configs" / "holder_wrap").glob("*.yaml")
 
     for det in dets:
-        
-        print(det.stem)
+        # skip the special detectors
+        if str(det.stem) in ["V02162B", "V02160A", "V07646A"] and public_geom:
+            continue
+
         daq_settings2 = AttrsDict({"flashcam": {"card_interface": "efb2"}})
         pos = AttrsDict({"phi_in_deg": 0.0, "r_in_mm": 0.0, "z_in_mm": 38.0})
         reg = construct(
-                AttrsDict({
+            AttrsDict(
+                {
                     "detector": str(det.stem),
                     "campaign": "c1",
                     "measurement": "am_HS6_top_dlt",
                     "daq_settings": daq_settings2,
                     "source_position": pos,
-                }),
-            public_geometry=True,
+                }
+            ),
+            public_geometry=public_geom,
         )
         assert isinstance(reg, geant4.Registry)
         pygeomtools.geometry.check_registry_sanity(reg, reg)
@@ -123,15 +127,3 @@ def test_translate_to_detector_frame():
     assert x == 0.0
     assert y == 0.0
     assert z == 38.0
-
-def test_all_detectors():
-    dets = Path(resources.files("pygeomhades") / "configs" / "holder_wrap").glob("*.yaml")
-
-    for det in dets:
-        reg = construct(
-            str(det.stem),
-            "am_HS1_top_dlt",
-            config={"lead_castle_idx": 2},
-            public_geometry=True,
-        )
-        assert isinstance(reg, geant4.Registry)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,6 +89,25 @@ def test_construct():
             public_geometry=True,
         )
 
+
+def test_all_detectors():
+    dets = Path(resources.files("pygeomhades") / "configs" / "holder_wrap").glob("*.yaml")
+
+    for det in dets:
+        
+        print(det.stem)
+        daq_settings2 = AttrsDict({"flashcam": {"card_interface": "efb2"}})
+        pos = AttrsDict({"phi_in_deg": 0.0, "r_in_mm": 0.0, "z_in_mm": 38.0})
+        reg = construct(
+                AttrsDict({
+                    "detector": str(det.stem),
+                    "campaign": "c1",
+                    "measurement": "am_HS6_top_dlt",
+                    "daq_settings": daq_settings2,
+                    "source_position": pos,
+                }),
+            public_geometry=True,
+        )
         assert isinstance(reg, geant4.Registry)
         pygeomtools.geometry.check_registry_sanity(reg, reg)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -95,7 +95,7 @@ def test_all_detectors():
 
     for det in dets:
         # skip the special detectors
-        if str(det.stem) in ["V02162B", "V02160A", "V07646A"] and public_geom:
+        if str(det.stem) in ["V02162B", "V02160A", "V07646A", "V06649A"] and public_geom:
             continue
 
         daq_settings2 = AttrsDict({"flashcam": {"card_interface": "efb2"}})


### PR DESCRIPTION
This test tries to call construct for every detector. It thus provides us a check on the wrap and holder metadata.

Currently the test does not pass...