### PR TITLE
[bugfix] fix the cryostat geometry for ic detectors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,21 @@ jobs:
         run: |
           python -m pytest
 
+  test-remage:
+    name: Test legend-pygeom-hades with remage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Pixi
+        uses: prefix-dev/setup-pixi@v0.9.3
+        with:
+          environments: test
+
+      - name: Run tests
+        run: |
+          pixi run -e test pytest --runxfail -m needs_remage
+
   test-coverage:
     name: Calculate and upload test coverage
     needs: build-and-test

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+pixi.lock
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,11 @@ xfail_strict = true
 filterwarnings = "error"
 log_cli_level = "info"
 testpaths = "tests"
+markers = [
+    "needs_remage: tests that require a remage installation",
+]
+
+
 
 [tool.codespell]
 ignore-words-list = "manuel,tre"
@@ -140,3 +145,18 @@ isort.required-imports = ["from __future__ import annotations"]
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["T20"]
 "noxfile.py" = ["T20"]
+
+
+[tool.pixi.workspace]
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[tool.pixi.pypi-dependencies]
+legend_pygeom_hades = { path = ".", editable = true }
+
+[tool.pixi.feature.test.dependencies]
+remage = ">=0.18,<0.19"
+
+[tool.pixi.environments]
+default = { solve-group = "default" }
+test = { features = ["test"], solve-group = "default" }

--- a/src/pygeomhades/dimensions.py
+++ b/src/pygeomhades/dimensions.py
@@ -47,11 +47,12 @@ def get_cryostat_metadata(det_type: str, order: int, xtal_slice: str) -> AttrsDi
     if det_type == "bege":
         cryostat["height"] = 122.2
         cryostat["width"] = 101.6
-
     elif (det_type == "icpc") and (order in xl_orders):
         cryostat["width"] = 114.3
+        cryostat["height"] = 171.0
     elif det_type == "icpc":
         cryostat["width"] = 101.6
+        cryostat["height"] = 171.0
     else:
         msg = "Only detector type icpc or bege are supported."
         raise ValueError(msg)

--- a/tests/test_remage.py
+++ b/tests/test_remage.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+
+import pygeomtools
+import pytest
+
+from pygeomhades import core
+
+public_geom = os.getenv("LEGEND_METADATA", "") == ""
+
+pytestmark = [
+    pytest.mark.xfail(run=True, reason="requires a remage installation"),
+    pytest.mark.needs_remage,
+]
+
+
+@pytest.fixture
+def gdml_file(tmp_path):
+    reg = core.construct(
+        "V07302A",  # this works since its larger than the test detector
+        "am_HS1_top_dlt",
+        config={"lead_castle_idx": 1},
+        public_geometry=True,
+    )
+
+    gdml_file = tmp_path / "hades-public.gdml"
+    pygeomtools.write_pygeom(reg, gdml_file)
+
+    return gdml_file
+
+
+def test_overlaps(gdml_file):
+    from remage import remage_run
+
+    macro = [
+        "/RMG/Geometry/RegisterDetectorsFromGDML Germanium",
+        "/run/initialize",
+    ]
+
+    remage_run(macro, gdml_files=str(gdml_file), raise_on_error=True, raise_on_warning=True)


### PR DESCRIPTION
Fix of the cryostat dimensions for the IC.

This means that now the public geometry does not contain overlaps. I think it works as long as the chosen detector is larger than the V09999A in metadata.
  

