### PR TITLE
Allow the copper plate to work

### DIFF
--- a/src/pygeomhades/core.py
+++ b/src/pygeomhades/core.py
@@ -55,7 +55,7 @@ def _place_pv(
         rot,
         [x_in_mm, y_in_mm, z_in_mm, "mm"],
         lv,
-        name,
+        name.replace("_lv", ""),  # strip _lv from name
         mother_lv,
         registry=reg,
     )
@@ -227,8 +227,7 @@ def construct(
         reg.addVolumeRecursive(pv)
 
         if table == 2:
-            msg = "For the lead castle the copper plate is not implemented!"
-            log.warning(msg)
+            reg.logicalVolumeDict["Copper_plate"].pygeom_color_rgba = [0.8, 0.6, 0.4, 0.2]
 
     if "source" in assemblies:
         if not construct_unverified:

--- a/src/pygeomhades/create_volumes.py
+++ b/src/pygeomhades/create_volumes.py
@@ -228,7 +228,7 @@ def create_bottom_plate(plate_metadata: AttrsDict, from_gdml: bool = True) -> ge
 
 
 def create_lead_castle(
-    table_num: int, castle_dimensions: AttrsDict, from_gdml: bool = True, volume_name: str = "Lead_castle"
+    table_num: int, castle_dimensions: AttrsDict, from_gdml: bool = True
 ) -> geant4.LogicalVolume:
     """Create the lead castle.
 
@@ -303,7 +303,7 @@ def create_lead_castle(
             "copper_plate_height": castle_dimensions.copper_plate.height,
         }
 
-    return read_gdml_with_replacements(dummy_gdml_path, replacements, vol_name=volume_name)
+    return read_gdml_with_replacements(dummy_gdml_path, replacements)
 
 
 def create_source(

--- a/src/pygeomhades/utils.py
+++ b/src/pygeomhades/utils.py
@@ -72,7 +72,7 @@ def merge_configs(diode_meta: AttrsDict, extra_meta: Mapping, *, extra_name: str
 
 
 def read_gdml_with_replacements(
-    dummy_gdml_path: Path, replacements: Mapping, vol_name: str | None = None
+    dummy_gdml_path: Path, replacements: Mapping
 ) -> geant4.LogicalVolume | dict[str, geant4.LogicalVolume]:
     """Read a GDML file including replacements.
 
@@ -92,10 +92,8 @@ def read_gdml_with_replacements(
     with tempfile.NamedTemporaryFile("w+", suffix=".gdml") as f:
         f.write(gdml_text)
         f.flush()
-        reader = gdml.Reader(f.name)
 
+        reader = gdml.Reader(f.name)
         reg_tmp = reader.getRegistry()
 
-    if len(reg_tmp.logicalVolumeList) == 1:
-        return next(iter(reg_tmp.logicalVolumeDict.values()))
-    return reg_tmp.logicalVolumeDict[vol_name]
+    return reg_tmp.worldVolume


### PR DESCRIPTION
This actually works without any modification since if the world volume is placed in another registry then `reg.addVolumeRecursive` is called, all the daughter volumes (for example this copper plate) have their ownership transferred to the main registry.

We can see the placement looks correct. This solves #17 .

<img width="899" height="751" alt="image" src="https://github.com/user-attachments/assets/300ae4a7-a41c-4b4c-b79f-3bd47c52a613" />


@vbiancacci this may well help for the source and holder