### PR TITLE
chore: update package authors

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,3 +7,12 @@ authors:
   - family-names: Pertoldi
     given-names: Luigi
     orcid: https://orcid.org/0000-0002-0467-2571
+  - family-names: Dixon
+    given-names: Toby
+    orcid: https://orcid.org/0000-0001-8787-6336
+  - family-names: Biancacci
+    given-names: Valentina
+    orcid: https://orcid.org/0000-0002-1328-8950
+  - family-names: Huber
+    given-names: Manuel
+    orcid: https://orcid.org/0009-0000-5212-2999

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ name = "legend_pygeom_hades"
 description = "Geometry model of the LEGEND HPGe test stand at HADES"
 authors = [
     { name = "Valentina Biancacci", email = "valentina.biancacci@gssi.it" },
-    { name = "William Quinn", email = "william.quinn.14@ucl.ac.uk" },
     { name = "Toby Dixon", email = "toby.dixon.23@ucl.ac.uk" },
     { name = "Luigi Pertoldi", email = "gipert@pm.me" },
+    { name = "Manuel Huber", email = "info@manuelhu.de" },
 ]
 maintainers = [
     { name = "The LEGEND Collaboration" },


### PR DESCRIPTION
Adds Toby Dixon, Valentina Biancacci and Manuel Huber to `CITATION.cff` (ORCIDs taken from the other LEGEND packages, Biancacci's from her ORCID record). Also adds Manuel Huber to and removes William Quinn from the `pyproject.toml` author list.