### PR TITLE
chore: fill in Zenodo DOI in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 title: legend-pygeom-hades
-doi: FILL-ME
-date-released: 2025-08-08
+doi: 10.5281/zenodo.22029996
+date-released: 2026-08-20
 message: "If you use this software, please cite it as below."
 authors:
   - family-names: Pertoldi


### PR DESCRIPTION
Replaces the `FILL-ME` placeholder with the Zenodo concept DOI (`10.5281/zenodo.22029996`), which resolves to the latest version, consistently with the other legend-pygeom packages. Also sets `date-released` to the v0.2.1 release date (the previous value predated any release).